### PR TITLE
Move terraform backend configuration out of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# Custom backend setup
+backend-config

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -37,6 +37,11 @@ spec:
   environment {
     AWS_ACCESS_KEY_ID = credentials("${CREDENTIAL_BASE_ID}-access-key")
     AWS_SECRET_ACCESS_KEY = credentials("${CREDENTIAL_BASE_ID}-secret-key")
+    // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_in_automation
+    TF_IN_AUTOMATION = '1'
+    // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_input
+    TF_INPUT = '0'
+    BACKEND_CONFIG_FILE = credentials("${CREDENTIAL_BASE_ID}-backend-config")
   }
 
   stages {

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,13 @@
 # Ref. https://golang.org/cmd/cgo/
 export CGO_ENABLED=0
 
+BACKEND_CONFIG_FILE ?= ./backend-config
+
 help: ## Show this Makefile's help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 prepare: ## Prepare Terraform's environment by downloading and initializing its plugins and backends
-	@terraform init
+	@terraform init -backend-config=$(BACKEND_CONFIG_FILE)
 
 validate: prepare ## Run a static validation on the local files
 	@terraform validate

--- a/backend.tf
+++ b/backend.tf
@@ -1,10 +1,5 @@
 
 terraform {
-  backend "s3" {
-    bucket  = "tf-remote-state20210218182205331500000003"
-    encrypt = true
-    kms_key_id = "32bfc103-dd08-4186-8b93-162146524d42"
-    key        = "terraform.tfstate"
-    region     = "us-east-1"
-  }
+  # Use "terraform init -backend-config=PATH" to setup state in a s3 bucket
+  backend "s3" {}
 }


### PR DESCRIPTION
This PR aims at removing the terraform S3 backend setup out of the repository, to move it as encrypted credentials depending on the target environment (ci for testing or production).

Requires https://github.com/jenkins-infra/charts/pull/920 to be merged and applied (any builds before are done with a temp. credential on infra.ci)