### PR TITLE
Enable Terratest Linting

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -20,7 +20,7 @@ kind: Pod
 spec:
   containers:
   - name: terraform
-    image: jenkinsciinfra/terraform@sha256:8b9c95c1e8206f812d6946657ef73b0210c8e4d7143b71778afd79ef31632cee # 1.1.0 tag
+    image: jenkinsciinfra/terraform@sha256:5abf75840de08d6bbd27687ae787a02f5cce447fc3f69b5af2232deaeb5206a0 # https://github.com/jenkins-infra/docker-terraform/releases/tag/1.2.0
     command:
     - cat
     tty: true

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ validate: prepare ## Run a static validation on the local files
 	@terraform validate
 	@tfsec --exclude-downloaded-modules
 	## Enable test's code linting. Requires golangci-lint to be installed in the image
-	# @golangci-lint run ./tests/
+	@golangci-lint run ./tests/
 
 tests: ## Execute the test harness
 	@go test -v -timeout 30m ./tests/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ prepare: ## Prepare Terraform's environment by downloading and initializing its 
 validate: prepare ## Run a static validation on the local files
 	@terraform validate
 	@tfsec --exclude-downloaded-modules
-	## Enable test's code linting. Requires golangci-lint to be installed in the image
+	@go fmt ./tests/
 	@golangci-lint run ./tests/
 
 tests: ## Execute the test harness

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,43 @@
+= Jenkins Infra on AWS
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+:toc:
+
+This repository is meant to hold documentation, tooling and other resources
+related to the link:https://www.jenkins.io/projects/infrastructure/[Jenkins Infrastructure Project] parts hosted in
+link:https://aws.amazon.com/[Amazon Web Services (AWS)].
+
+== Requirements
+
+In order to use this repository to provision the Jenkins infrastructure on AWS, you need:
+
+* An AWS account. Please note that The Jenkins infrastructure uses 2 AWS accounts configured in infra.ci.jenkins:
+** `ci-terraform` to allow PRs and testing without impacting the production
+** `production-terraform` to apply changes to production
+* CLI tooling (Please note that infra.ci.jenkins.io uses a Docker image built from https://github.com/jenkins-infra/docker-terraform with the up-to-date requirements):
+** Terraform v0.13.x CLI to provision the infrastructure
+** GNU `make` to ease running the tasks involved in this provisionning
+** link:https://github.com/tfsec/tfsec[tfsec]
+** link:https://golang.org/[Golang] and link:https://github.com/golangci/golangci-lint[golangci-lint] to allow testing with link:https://terratest.gruntwork.io/[terratest]
+
+== HowTo
+
+=== Provision
+
+IMPORTANT: Don't blindly execute the terraform code located in this repository on your own account as it may lead your account bill to significantly increase.
+
+Once you fulfill the requirements, you can use the code located here to provision this infrastructure on your AWS account
+
+* Create a file named `backend-config`, as a "properties file format" (e.g. "key=value" per line) to configure the link:https://www.terraform.io/docs/language/settings/backends/s3.html[Terraform S3 Backend storing state]
+** This setup is automatically done by infra.ci.jenkins (`backend-config` is git-ignored)
+
+* Run `make help` to print the Makefile manual with all available targets (useful when this `README` is not synced with the `Makefile`)
+
+* Run `make prepare` to initialize the local Terraform project (e.g. generates `.terraform` and retrieve dependencies, using the S3 backend)
+
+* Run `make validate` to run a static analysis of the project (both Terraform and terratest code)
+
+* Run `make test` to execute the test harness on the project (uses the terratest code in `./tests/`)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# experiment-aws
-an experimental repository for AWS terraform scripts


### PR DESCRIPTION
This PR enables linting of the terratest golang code using golangci-lint (as https://github.com/jenkins-infra/docker-terraform/pull/10 added this tool in the image)