### PR TITLE
Update Pipeline behavior to cover the 4 possible workflows

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -106,10 +106,7 @@ pipeline {
                 }
               }
               steps {
-                input {
-                  message "Should we apply these changes to production?"
-                  ok "🚢 Yes, ship it!"
-                }
+                input message: "Should we apply these changes to production?", ok: "🚢 Yes, ship it!"
               }
             }
             stage('🚢 Shipping Changes') {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -116,11 +116,6 @@ pipeline {
                   not { triggeredBy 'TimerTrigger' }
                 }
               }
-              // Pipeline is timeouted
-              input {
-                message "Should we apply these changes to production?"
-                ok "🚢 Yes, ship it!"
-              }
               steps {
                 sh 'make deploy'
               }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -116,7 +116,7 @@ pipeline {
             }
             stage('🚢 Shipping Changes') {
               when {
-                allof {
+                allOf {
                   branch 'main'
                   not { triggeredBy 'TimerTrigger' }
                 }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -105,13 +105,11 @@ pipeline {
                   triggeredBy 'UserIdCause'
                 }
               }
-              // Pipeline is timeouted
-              input {
-                message "Should we apply these changes to production?"
-                ok "🚢 Yes, ship it!"
-              }
               steps {
-                echo "GO GO GO"
+                input {
+                  message "Should we apply these changes to production?"
+                  ok "🚢 Yes, ship it!"
+                }
               }
             }
             stage('🚢 Shipping Changes') {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,20 +1,5 @@
 
-// The production credentials are only used on the main branch, when the build is triggered by code push or a human
-// On branches, PR, or the daily rebuild, then tests are run, no deployment are executed, and the "non production" credentials are used
-def CREDENTIAL_BASE_ID = 'ci-terraform'
-if (env.BRANCH_NAME == 'main' && !currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause')) {
-  CREDENTIAL_BASE_ID = 'production-terraform'
-}
-
-pipeline {
-  triggers {
-    // Build once per day if not a Pull Request or not a tag build
-    cron(env.CHANGE_ID || env.TAG_NAME ? '' : '@daily')
-  }
-
-  agent {
-    kubernetes {
-      yaml """
+def podTemplate = """
 apiVersion: v1
 kind: Pod
 spec:
@@ -25,72 +10,129 @@ spec:
     - cat
     tty: true
 """
-      defaultContainer('terraform')
-    }
+
+pipeline {
+  triggers {
+    // Build once per day if not a Pull Request or not a tag build
+    cron(env.CHANGE_ID || env.TAG_NAME ? '' : '@daily')
   }
+
+  agent none
 
   options {
     buildDiscarder(logRotator(numToKeepStr: '5'))
     timeout(time: 1, unit: 'HOURS')
     disableConcurrentBuilds()
+    parallelsAlwaysFailFast()
   }
 
   environment {
-    AWS_ACCESS_KEY_ID = credentials("${CREDENTIAL_BASE_ID}-access-key")
-    AWS_SECRET_ACCESS_KEY = credentials("${CREDENTIAL_BASE_ID}-secret-key")
     // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_in_automation
     TF_IN_AUTOMATION = '1'
     // https://www.terraform.io/docs/cli/config/environment-variables.html#tf_input
     TF_INPUT = '0'
-    BACKEND_CONFIG_FILE = credentials("${CREDENTIAL_BASE_ID}-backend-config")
   }
 
   stages {
-    stage('🧹 Prepare Terraform Environment') {
-      steps {
-        sh 'make prepare'
-      }
-    }
-    stage('🔎 Validate Terraform Project') {
-      steps {
-        sh 'make validate'
-      }
-    }
-    stage('✅ Test Terraform Project') {
-      when {
-        // Do not run tests with the production credentials to avoid polluting production Terraform workspaces
-        expression {
-          return CREDENTIAL_BASE_ID != 'production-terraform'
-        }
-      }
-      steps {
-        sh 'make tests'
-      }
-    }
-    stage('🚀 Deploy Production') {
-      when {
-        // Only run on the main branch
-        expression {
-          return CREDENTIAL_BASE_ID == 'production-terraform'
-        }
-      }
-      stages {
-        stage('🦅 Generate Terraform Plan') {
-          steps {
-            sh 'make plan'
+    stage('Check') {
+      parallel {
+        stage('Staging') {
+          when {
+            // The tests on staging environment runs on a PR, or on the daily cron job
+            anyOf {
+              changeRequest()
+              triggeredBy 'TimerTrigger'
+            }
+          }
+          agent {
+            kubernetes {
+              yaml podTemplate
+              defaultContainer('terraform')
+            }
+          }
+          environment {
+            AWS_ACCESS_KEY_ID = credentials("ci-terraform-access-key")
+            AWS_SECRET_ACCESS_KEY = credentials("ci-terraform-secret-key")
+            BACKEND_CONFIG_FILE = credentials("ci-terraform-backend-config")
+          }
+          stages {
+            stage('🧹 Prepare Terraform for Staging Environment') {
+              steps {
+                sh 'make prepare'
+              }
+            }
+            stage('🔎 Validate Terraform for Staging Environment') {
+              steps {
+                sh 'make validate'
+              }
+            }
+            stage('✅ Test Terraform Project') {
+              steps {
+                sh 'make tests'
+              }
+            }
           }
         }
-        stage('🚢  Shipping Changes') {
-          // Pipeline is timeouted
-          input {
-            message "Should we apply these changes to production?"
-            ok "🚢 Yes, ship it!"
+        stage('Production') {
+          agent {
+            kubernetes {
+              yaml podTemplate
+              defaultContainer('terraform')
+            }
           }
-          steps {
-            sh 'make deploy'
+          environment {
+            AWS_ACCESS_KEY_ID = credentials("production-terraform-access-key")
+            AWS_SECRET_ACCESS_KEY = credentials("production-terraform-secret-key")
+            BACKEND_CONFIG_FILE = credentials("production-terraform-backend-config")
           }
-        }
+          stages {
+            stage('🦅 Generate Terraform Plan') {
+              environment {
+                // When the job is triggered by the daily cron timer, then the plan succeed only if there is no changes found (e.g. no config drift)
+                // For all other triggers, the plan succeed either there are changes or not
+                TF_CLI_ARGS_plan="${currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause') ? '-detailed-exitcode' : ''}"
+              }
+              steps {
+                sh 'make plan'
+              }
+            }
+            stage("⏳ Waiting for User Manual Approval") {
+              agent none
+              when {
+                // The Wait for human input is only required when a user manually launched the pipeline on the main branch
+                allOf {
+                  branch 'main'
+                  triggeredBy 'UserIdCause'
+                }
+              }
+              // Pipeline is timeouted
+              input {
+                message "Should we apply these changes to production?"
+                ok "🚢 Yes, ship it!"
+              }
+              steps {
+                echo "GO GO GO"
+              }
+            }
+            stage('🚢 Shipping Changes') {
+              when {
+                allof {
+                  branch 'main'
+                  not { triggeredBy 'TimerTrigger' }
+                }
+              }
+              // Pipeline is timeouted
+              input {
+                message "Should we apply these changes to production?"
+                ok "🚢 Yes, ship it!"
+              }
+              steps {
+                sh 'make deploy'
+              }
+            }
+          }
+        } // stage('Production')
       }
-    }
+    } // stage('Check')
   }
 }

--- a/README.adoc
+++ b/README.adoc
@@ -41,3 +41,15 @@ Once you fulfill the requirements, you can use the code located here to provisio
 * Run `make validate` to run a static analysis of the project (both Terraform and terratest code)
 
 * Run `make test` to execute the test harness on the project (uses the terratest code in `./tests/`)
+
+=== Pipeline's Workflows
+
+The `Jenkinsfile_k8s` pipeline describe the workflows for this GitOps system.
+
+There 4 possible workflows:
+
+* When on a Pull Request, then the tests are run on the staging environment AND a terraform plan is run on the production environment (to give the maintainer an idea of what should happen if the PR is merged)
+* When on the principal branch:
+** By default (e.g. a code push, mostly from PR merged), a terraform plan is run on the production AND a deployment is done if the plan succeeds.
+** If the trigger is the daily cron, then all tests are run on the staging AND a terraform plan is run on the production. Please note that if the plan detects changes, then it fails because a configuration drift happened.
+** If the trigger is manual, then no tests are run at all, a terraform plan is run on the production and a human must approve the pipeline for the deployment to production to happen


### PR DESCRIPTION
Documentation (`README`) has been updated to describe the 4 foreseen use cases:

* PR: tests + terraform plan to show changes
* build on main, triggered by a code push: no tests, terraform plan, and terraform apply => either a PR merge or an admin's direct push to `main`
* Daily build on main (triggered by cron timer): run tests + a terraform plan with detailled exit code. If there are resource changes in the plan (e.g. a configuration drift between state, repo and production), then the plan fails
* Manual build on main (triggered by a human): no tests, terraform plan, and then wait for user manual input (1 hour max: the pipeline has a timeout). If a humans clicks "ship it", then terraform apply

