### PR TITLE
Configure Kubernetes Auth from IAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ override.tf.json
 
 # Custom backend setup
 backend-config
+kubeconfig*

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,16 +1,3 @@
-
-def podTemplate = """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: terraform
-    image: jenkinsciinfra/terraform@sha256:5abf75840de08d6bbd27687ae787a02f5cce447fc3f69b5af2232deaeb5206a0 # https://github.com/jenkins-infra/docker-terraform/releases/tag/1.2.0
-    command:
-    - cat
-    tty: true
-"""
-
 pipeline {
   triggers {
     // Build once per day if not a Pull Request or not a tag build
@@ -47,7 +34,7 @@ pipeline {
           }
           agent {
             kubernetes {
-              yaml podTemplate
+              yamlFile 'ci-pod-template.yml'
               defaultContainer('terraform')
             }
           }
@@ -77,7 +64,7 @@ pipeline {
         stage('Production') {
           agent {
             kubernetes {
-              yaml podTemplate
+              yamlFile 'ci-pod-template.yml'
               defaultContainer('terraform')
             }
           }

--- a/ci-pod-template.yml
+++ b/ci-pod-template.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+spec:
+  automountServiceAccountToken: false
+  containers:
+  - name: terraform
+    # https://github.com/jenkins-infra/docker-terraform/releases/tag/1.3.0
+    image: jenkinsciinfra/terraform@sha256:0a7013e1db0185d87e3186843420bee2c25c103c692773244c538d81147804ec
+    command:
+    - cat
+    tty: true

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -35,6 +35,21 @@ module "eks" {
   workers_group_defaults = {
   	root_volume_type = "gp2"
   }
+
+  map_users = [
+    // User impersonnated when using the CloudBees IAM Accounts (e.g. humans)
+    {
+      userarn = "arn:aws:sts::200564066411:assumed-role/infra-admin/tba",
+      username = "infra-admin",
+      groups   = ["system:masters"],
+    },
+    // User defined in the Infra.CI system
+    {
+      userarn = "arn:aws:iam::200564066411:user/production-terraform",
+      username = "production-terraform",
+      groups   = ["system:masters"],
+    },
+  ]
 }
 
 data "aws_eks_cluster" "cluster" {

--- a/providers.tf
+++ b/providers.tf
@@ -4,3 +4,9 @@ provider "aws" {
 
 provider "local" {
 }
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}

--- a/versions.tf
+++ b/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 2.0.0"
     }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "~> 2.0.2"
+    }
   }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Define a Kubernetes Provider in terraform to allow configuration of the configmap `aws-auth` in the EKS cluster, as per https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest#usage-example
- Bump image `jenkinsciinfra/terraform` to `1.3.0` to have the `aws` and `aws-iam-authenticator` CLIs available (+ move the pod template to a YAMLfile)
- Add 2 IAM users to the `aws-auth` configmap: `production-terraform` to allow CI to grant the admin clusterrole in the EKS cluster + the `infra-admin` that can be impersonnated by any member of the AWS account organizaton