### PR TITLE
Feat/plan for human

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ override.tf.json
 # Custom backend setup
 backend-config
 kubeconfig*
+terraform-plan-for-humans.txt

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -81,7 +81,7 @@ pipeline {
                 TF_CLI_ARGS_plan="${currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause') ? '-detailed-exitcode' : ''}"
               }
               steps {
-                sh 'make plan > terraform-plan-for-humans.txt'
+                sh 'make plan'
               }
               post {
                 always {

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ tests: lint-tests ## Execute the test harness
 	@go test -v -timeout 30m ./tests/
 
 plan: lint .terraform/plugins/selections.json ## Deploy (apply) the terraform changes to production
-	@terraform plan -compact-warnings -lock=false
+	@terraform plan -compact-warnings -lock=false -no-color > terraform-plan-for-humans.txt
 
 deploy: lint .terraform/plugins/selections.json ## Deploy (apply) the terraform changes to production
 	@terraform apply -auto-approve

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -66,15 +66,15 @@ module "eks" {
     },
     // User for administrating the charts from github.com/jenkins-infra/charts
     {
-      userarn  = aws_iam_user.eks_charter.arn,
-      username = aws_iam_user.eks_charter.name,
+      userarn  = data.aws_iam_user.eks_charter.arn,
+      username = data.aws_iam_user.eks_charter.user_name,
       groups   = ["system:masters"],
     },
   ]
 }
 
-resource "aws_iam_user" "eks_charter" {
-  name = "eks_charter"
+data "aws_iam_user" "eks_charter" {
+  user_name = "eks_charter"
 }
 
 data "aws_eks_cluster" "cluster" {


### PR DESCRIPTION
As per our interactive review of #16 , @olblak suggested to make the `terraform-plan-for-humans.txt` more readable.

This PR changes the way it is generated:

* Delegated to `Makefile` instead of the pipeline to allow reproducibility and remove the Make "standard output decorators"
* Removing the color output of `terraform plan` to avoid unreadable output

Also, this PR introduces a change to the IAM user `eks_charter`, which is now a data source instead of a Terraform-managed resource:

* #16 implied a re-creation of the EKS cluster. Not an issue as we are not using it, the destruction of the cluster was failing with the error `Error: Error deleting IAM User eks_charter: DeleteConflict: Cannot delete entity, must delete access keys first.` because the user `eks_charter` has an API key not managed by terraform
* If the cluster has to be recreated in the future, it is not really an issue because it is stateless (only agent workload), but the API key is used in jenkins-infra/charts and it's not easy to rotate it (as it is encrypted).