### PR TITLE
Fix: switch EKS worker's AMI to a datasource

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -54,6 +54,7 @@ module "eks" {
   # This block is a temporary fix for https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1205
   workers_group_defaults = {
     root_volume_type = "gp2"
+    ami_id           = data.aws_ami.eks_linux_worker.id
   }
 
   map_users = [
@@ -88,4 +89,15 @@ data "aws_eks_cluster" "cluster" {
 
 data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.cluster_id
+}
+
+data "aws_ami" "eks_linux_worker" {
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-${var.kubernetes_version}-v*"]
+  }
+
+  most_recent = true
+
+  owners = ["amazon"]
 }


### PR DESCRIPTION
to get a fixed version over time

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>