### PR TITLE
INFRA-2904: add an EC2 keypair to allow infra.ci using ec2 agents

### DIFF
--- a/ec2-agents.tf
+++ b/ec2-agents.tf
@@ -1,0 +1,6 @@
+
+# This keypair shall be used to allow the Jenkins controller infra.ci to connect to the EC2 agents
+resource "aws_key_pair" "ec2_agents_infraci" {
+  key_name   = "ec2_agents_infraci"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILoYAkQkqbIyQWO3uwa6ZiJa5xBbEJ6yOzP8MDGnuXdg jenkins-infra@jenkins.io"
+}


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>