### PR TITLE
feat: increase upper limit of the main-linux ASG to 50 [INFRA-2918]

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -36,7 +36,7 @@ module "eks" {
       instance_type        = "t3a.2xlarge"
       asg_desired_capacity = 3
       asg_min_size         = 2
-      asg_max_size         = 15
+      asg_max_size         = 50
       public_ip            = false
       kubelet_extra_args   = "--node-labels=node.kubernetes.io/lifecycle=normal"
       suspended_processes  = ["AZRebalance"]


### PR DESCRIPTION
This PR increases the ASG size to 50 VM max, to ensure there are enough resources available on ci.jenkins.io, as part of INFRA-2918.