### PR TITLE
fix [INFRA-3086] increase max available IPs for EKS workers and pods

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -9,11 +9,19 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.3"
 
-  name                 = "${local.cluster_name}-vpc"
-  cidr                 = "10.0.0.0/16"
-  azs                  = data.aws_availability_zones.available.names
-  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  name = "${local.cluster_name}-vpc"
+  cidr = "10.0.0.0/16"
+  azs  = data.aws_availability_zones.available.names
+  private_subnets = [
+    "10.0.16.0/20", # 10.0.16.1 -> 10.0.31.254 (4096 hosts)
+    "10.0.32.0/20", # 10.0.32.1 -> 10.0.47.254 (4096 hosts)
+    "10.0.64.0/20", # 10.0.64.1 -> 10.0.79.254 (4096 hosts)
+  ]
+  public_subnets = [
+    "10.0.0.0/29",  # 10.0.0.1 -> 10.0.0.7 (6 hosts + broadcast)
+    "10.0.0.8/29",  # 10.0.0.9 -> 10.0.0.15 (6 hosts + broadcast)
+    "10.0.0.16/29", # 10.0.0.17 -> 10.0.0.22 (6 hosts + broadcast)
+  ]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true


### PR DESCRIPTION
This PR aims at fixiking INFRA-3086 with the following changes:

- public subnet ranges are move at the beginning of the VPC range + decresead for 6 hosts each (no need for much input routes)
- private subnets are increased from 255 hosts (/24) to 4096 (/20)
