### PR TITLE
feat(eks) manage addons through terraform

### DIFF
--- a/eks-addons.tf
+++ b/eks-addons.tf
@@ -1,0 +1,18 @@
+
+# https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
+resource "aws_eks_addon" "kube-proxy" {
+  cluster_name = module.eks.cluster_id
+  addon_name   = "kube-proxy"
+}
+
+# https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
+resource "aws_eks_addon" "coredns" {
+  cluster_name = module.eks.cluster_id
+  addon_name   = "coredns"
+}
+
+# https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html
+resource "aws_eks_addon" "vpc-cni" {
+  cluster_name = module.eks.cluster_id
+  addon_name   = "vpc-cni"
+}


### PR DESCRIPTION
This PR follows up the Kubernetes 1.20 upgrade of EKS (in #44) .

It ensures that the EKS addons are now managed by Terraform, to ensure that it would be upgraded for the next cluster update (to 1.21).

To avoid errors due to IAM roles, we've initialized the addons for hte freshly upgraded 1.20 EKS cluster in AWS console WebUI, and the 3 resources had been imported in terraform in this PR with the following commands

```shell
terraform import aws_eks_addon.kube-proxy 'jenkins-infra-eks-ENRZrfwf:kube-proxy'
terraform import aws_eks_addon.coredns 'jenkins-infra-eks-ENRZrfwf:coredns'
terraform import aws_eks_addon.vpc-cni 'jenkins-infra-eks-ENRZrfwf:vpc-cni'
```