### PR TITLE
fix(eks) specify egress Sec. Group rules to allow pods to reach ci.jenkins.io and outside internet

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -32,6 +32,7 @@ module "eks" {
   # VPC is defined in vpc.tf
   vpc_id = module.vpc.vpc_id
 
+  ## Manage EKS addons with module
   cluster_addons = {
     coredns = {
       resolve_conflicts = "OVERWRITE"
@@ -73,6 +74,37 @@ module "eks" {
         "k8s.io/cluster-autoscaler/enabled"               = true,
         "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned",
       }
+    },
+  }
+
+  # Allow egress from nodes (and pods...)
+  node_security_group_additional_rules = {
+    egress_jenkins_jnlp = {
+      description      = "Allow egress to Jenkins TCP"
+      protocol         = "TCP"
+      from_port        = 50000
+      to_port          = 50000
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    },
+    egress_http = {
+      description      = "Allow egress to plain HTTP"
+      protocol         = "TCP"
+      from_port        = 80
+      to_port          = 80
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    },
+    egress_https = {
+      description      = "Allow egress to HTTPS"
+      protocol         = "TCP"
+      from_port        = 443
+      to_port          = 443
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
     },
   }
 }


### PR DESCRIPTION
Ref. https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest#security-groups

By upgrading the EKS module in #92  , the security groups for egress was restricted from "open bar" to "only some ports".

The port `50000` used by inbound agents was forbidden:
- ci.jenkins.io was able to start the agent pods
- agent pods were failing while connecting to ci.jenkins.io on this port with the following log excerpt:

```
INFO: Connecting to ci.jenkins.io:50000
Feb 14, 2022 4:04:57 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Connecting to ci.jenkins.io:50000 (retrying:2)
java.io.IOException: Failed to connect to ci.jenkins.io:50000
        at org.jenkinsci.remoting.engine.JnlpAgentEndpoint.open(JnlpAgentEndpoint.java:248)
```