### PR TITLE
chore: bump hashicorp within jenkinsfile

### DIFF
--- a/updatecli/updatecli.d/hashicorp.yml
+++ b/updatecli/updatecli.d/hashicorp.yml
@@ -1,0 +1,53 @@
+title: Bump Jenkinsfile_k8s for updatecli `hashicorp-tools` docker image version to lastest image release
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  dockerHashicorpToolsImageVersion:
+    kind: githubRelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "docker-hashicorp-tools"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkIfDockerImageIsPublished:
+    name: "Check if the Docker Image is published"
+    kind: dockerImage
+    spec:
+      image: "jenkinsciinfra/hashicorp-tools"
+      architecture: amd64
+
+targets:
+  updateJenkinsfile:
+    name: Update jenkinsfile_k8s file in groovy code
+    kind: file
+    spec:
+      file: ./Jenkinsfile_k8s
+      # Please note that the patterns are specified as "block scalars" (>) - https://yaml-multiline.info/ - with the last endline trimmed (-) to avoid tedious escaping of simple quotes
+      matchpattern: >-
+        'jenkinsciinfra/hashicorp-tools:(.*)'
+      replacepattern: >-
+        'jenkinsciinfra/hashicorp-tools:{{ source `dockerHashicorpToolsImageVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateJenkinsfile
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
Keep track of the hashicorp image version used within jenkinsfile (for the use of updatecli himself).