### PR TITLE
chore: use instance type available in all AZ

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -44,11 +44,11 @@ module "eks-public" {
   }
 
   eks_managed_node_groups = {
-    arm-4c8g = {
+    arm-4c16g = {
       # This worker pool is expected to host public services such as artifact-caching-proxy, etc.
-      name                 = "arm-4c8g"
+      name                 = "arm-4c16g"
       ami_type             = "AL2_ARM_64"
-      instance_types       = ["a1.xlarge"]
+      instance_types       = ["t4g.xlarge"]
       capacity_type        = "ON_DEMAND"
       min_size             = 1
       max_size             = 2 # Allow manual scaling when running operations or upgrades


### PR DESCRIPTION
Error message with a1.xlarge:
> Your requested instance type (a1.xlarge) is not supported in your requested Availability Zone (us-east-2c). Please retry your request by not specifying an Availability Zone or choosing us-east-2a, us-east-2b

Fixup of #202 (a1.xlarge not available in us-east2a), #200 (AMI not autorizing ARM architecture)