### PR TITLE
fix(eks-public): manage aws-auth configmap and add users

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -93,7 +93,7 @@ module "eks-public" {
     # User for administrating the charts from github.com/jenkins-infra/kubernetes-management
     {
       userarn  = data.aws_iam_user.eks_public_charter.arn,
-      username = data.aws_iam_user.eks_charter.user_name,
+      username = data.aws_iam_user.eks_public_charter.user_name,
       groups   = ["system:masters"],
     },
   ]

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -73,6 +73,34 @@ module "eks-public" {
       ipv6_cidr_blocks = ["::/0"]
     },
   }
+
+  # aws-auth configmap
+  manage_aws_auth_configmap = true
+
+  aws_auth_users = [
+    # User impersonated when using the CloudBees IAM Accounts (e.g. humans)
+    {
+      userarn  = "arn:aws:iam::200564066411:role/infra-admin",
+      username = "infra-admin",
+      groups   = ["system:masters"],
+    },
+    # User defined in infra.ci.jenkins.io system to operate terraform
+    {
+      userarn  = "arn:aws:iam::200564066411:user/production-terraform",
+      username = "production-terraform",
+      groups   = ["system:masters"],
+    },
+    # User for administrating the charts from github.com/jenkins-infra/kubernetes-management
+    {
+      userarn  = data.aws_iam_user.eks_public_charter.arn,
+      username = data.aws_iam_user.eks_charter.user_name,
+      groups   = ["system:masters"],
+    },
+  ]
+
+  aws_auth_accounts = [
+    "200564066411",
+  ]
 }
 
 # Reference the existing user for administrating the charts from github.com/jenkins-infra/kubernetes-management

--- a/iam-role-nlb.tf
+++ b/iam-role-nlb.tf
@@ -13,5 +13,5 @@ resource "aws_iam_policy" "cluster_nlb" {
   description = "EKS cluster-nlb policy for cluster ${module.eks-public.cluster_id}"
   # JSON from https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.3/docs/install/iam_policy.json
   # Cf https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
-  policy      = file("iam-nlb-policy.json") #tfsec:ignore:aws-iam-no-policy-wildcards
+  policy = file("iam-nlb-policy.json") #tfsec:ignore:aws-iam-no-policy-wildcards
 }


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/aws/pull/200 as currently only the creator of the cluster can be authenticated.