### PR TITLE
fix: unique random suffix for eks-public cluster name

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,13 @@
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}
+
+resource "random_string" "suffix_public" {
+  length  = 8
+  special = false
+}
+
 locals {
   ## Load public keypars from the reference file
   # Each line is expected to holds an OpenSSH public key followed by a comment character ('#') and the name of the instance using the ec2 agents with this key
@@ -5,7 +15,7 @@ locals {
 
   # EKS related
   cluster_name                             = "jenkins-infra-eks-${random_string.suffix.result}"
-  public_cluster_name                      = "jenkins-infra-public-${random_string.suffix.result}"
+  public_cluster_name                      = "jenkins-infra-public-${random_string.suffix_public.result}"
   k8s_autoscaler_service_account_namespace = "autoscaler"
   k8s_autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler-chart"
   k8s_nlb_service_account_namespace        = "nlb"

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,10 +1,5 @@
 data "aws_availability_zones" "available" {}
 
-resource "random_string" "suffix" {
-  length  = 8
-  special = false
-}
-
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.14.4"


### PR DESCRIPTION
Follow-up of #200