### PR TITLE
fix(eks-public): use both private and public subnets

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -11,7 +11,7 @@ module "eks-public" {
   cluster_name = local.public_cluster_name
   # From https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
   cluster_version = var.kubernetes_version
-  subnet_ids      = module.vpc.public_subnets
+  subnet_ids      = concat(module.vpc.public_subnets, module.vpc.private_subnets)
   # Required to allow EKS service accounts to authenticate to AWS API through OIDC (and assume IAM roles)
   # useful for autoscaler, EKS addons, NLB and any AWS API usage
   # See list at https://github.com/terraform-aws-modules/terraform-aws-iam/tree/master/modules/iam-role-for-service-accounts-eks


### PR DESCRIPTION
Fix vpc-cni addon installation, tested locally.

Follow-up of https://github.com/jenkins-infra/aws/pull/218