### PR TITLE
fix: add more private subnets and use the first 3 of them for eks-cluster

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -11,7 +11,9 @@ module "eks" {
   cluster_name = local.cluster_name
   # From https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
   cluster_version = var.kubernetes_version
-  subnet_ids      = module.vpc.private_subnets
+  # Start is inclusive, end is exclusive (!): from index 0 to index 2 (https://www.terraform.io/language/functions/slice)
+  # We're using the 3 first private_subnets defined in vpc.tf for this cluster
+  subnet_ids      = slice(module.vpc.private_subnets, 0, 3)
   # Required to allow EKS service accounts to authenticate to AWS API through OIDC (and assume IAM roles)
   # useful for autoscaler, EKS addons and any AWS APi usage
   enable_irsa = true

--- a/vpc.tf
+++ b/vpc.tf
@@ -8,15 +8,21 @@ module "vpc" {
   cidr = "10.0.0.0/16"
   azs  = data.aws_availability_zones.available.names
   private_subnets = [
+    # first for eks-cluster
     "10.0.16.0/20", # 10.0.16.1 -> 10.0.31.254
     "10.0.32.0/20", # 10.0.32.1 -> 10.0.47.254
     "10.0.64.0/20", # 10.0.64.1 -> 10.0.79.254
+    # next for eks-public
+    "10.0.80.0/24", # 10.0.80.1 -> 10.0.80.254
+    "10.0.81.0/24", # 10.0.81.1 -> 10.0.81.254
+    "10.0.82.0/24", # 10.0.82.1 -> 10.0.82.254
   ]
   public_subnets = [
     "10.0.0.16/28", # 10.0.0.17 -> 10.0.0.30
     "10.0.0.32/28", # 10.0.0.33 -> 10.0.0.46
     "10.0.0.48/28", # 10.0.0.49 -> 10.0.0.62
   ]
+
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true


### PR DESCRIPTION
Make some space to allow deploying vpc-cni addon without issue as it needs a block of /28 available IPs (16)
Cf https://aws.amazon.com/premiumsupport/knowledge-center/eks-cni-plugin-troubleshooting/

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752