### PR TITLE
fix: allow assume autoscaler role via irsa for eks-public

### DIFF
--- a/eks-role-autoscaler.tf
+++ b/eks-role-autoscaler.tf
@@ -1,4 +1,4 @@
-module "eks_iam_role_autoscaler" {
+module "eks_iam_assumable_role_autoscaler_eks" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.5.0"
   create_role                   = true
@@ -8,9 +8,19 @@ module "eks_iam_role_autoscaler" {
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.k8s_autoscaler_service_account_namespace}:${local.k8s_autoscaler_service_account_name}"]
 }
 
+module "eks_iam_assumable_role_autoscaler_eks_public" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "5.5.0"
+  create_role                   = true
+  role_name                     = "cluster-autoscaler"
+  provider_url                  = replace(module.eks-public.cluster_oidc_issuer_url, "https://", "")
+  role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.k8s_autoscaler_service_account_namespace}:${local.k8s_autoscaler_service_account_name}"]
+}
+
 resource "aws_iam_policy" "cluster_autoscaler" {
   name_prefix = "cluster-autoscaler"
-  description = "EKS cluster-autoscaler policy for cluster ${module.eks.cluster_id}"
+  description = "EKS cluster-autoscaler policy"
   policy      = data.aws_iam_policy_document.cluster_autoscaler.json
 }
 

--- a/eks-role-autoscaler.tf
+++ b/eks-role-autoscaler.tf
@@ -1,4 +1,6 @@
-module "eks_iam_assumable_role_autoscaler_eks" {
+## TODO: Proceed to renaming
+# module "eks_iam_assumable_role_autoscaler_eks" {
+module "eks_iam_role_autoscaler" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.5.0"
   create_role                   = true


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/2752

<details>
<summary>Current autoscaler pod error log:</summary>

```
encoding/json.(*Decoder).refill(0x4000b2c280)
    /usr/local/go/src/encoding/json/stream.go:165 +0x18c
encoding/json.(*Decoder).readValue(0x4000b2c280)
    /usr/local/go/src/encoding/json/stream.go:140 +0xac
encoding/json.(*Decoder).Decode(0x4000b2c280, {0x3066f20, 0x4000b78540})
    /usr/local/go/src/encoding/json/stream.go:63 +0x68
k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x4000b6b320, {0x4000b41400, 0x400, 0x400})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x1e8
k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x40008679f0, 0x0, {0x3d8f808, 0x4000b7a680})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0x70
k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000b1e2c0)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x60
k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x4000b7a640)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xb4
created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x110

goroutine 343 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0x4000b2a460, 0x1)
    /usr/local/go/src/runtime/sema.go:513 +0x168
sync.(*Cond).Wait(0x4000b2a450)
    /usr/local/go/src/sync/cond.go:56 +0xe4
golang.org/x/net/http2.(*pipe).Read(0x4000b2a448, {0x40007c4001, 0x1dff, 0x1dff})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/golang.org/x/net/http2/pipe.go:65 +0xf4
golang.org/x/net/http2.transportResponseBody.Read({0x4000b2a420}, {0x40007c4001, 0x1dff, 0x1dff})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/golang.org/x/net/http2/transport.go:2104 +0x80
encoding/json.(*Decoder).refill(0x4000b2cb40)
    /usr/local/go/src/encoding/json/stream.go:165 +0x18c
encoding/json.(*Decoder).readValue(0x4000b2cb40)
    /usr/local/go/src/encoding/json/stream.go:140 +0xac
encoding/json.(*Decoder).Decode(0x4000b2cb40, {0x3066f20, 0x4000772270})
    /usr/local/go/src/encoding/json/stream.go:63 +0x68
k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x4000b6b860, {0x40009da000, 0x2000, 0x2600})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x1e8
k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x4000867c20, 0x0, {0x3d8f808, 0x4000cc1d80})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0x70
k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000b1e320)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x60
k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x4000b7aac0)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xb4
created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x110

goroutine 344 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0x4000839e80, 0x0)
    /usr/local/go/src/runtime/sema.go:513 +0x168
sync.(*Cond).Wait(0x4000839e70)
    /usr/local/go/src/sync/cond.go:56 +0xe4
golang.org/x/net/http2.(*pipe).Read(0x4000839e68, {0x4000b36200, 0x200, 0x200})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/golang.org/x/net/http2/pipe.go:65 +0xf4
golang.org/x/net/http2.transportResponseBody.Read({0x4000839e40}, {0x4000b36200, 0x200, 0x200})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/golang.org/x/net/http2/transport.go:2104 +0x80
encoding/json.(*Decoder).refill(0x4000b2cc80)
    /usr/local/go/src/encoding/json/stream.go:165 +0x18c
encoding/json.(*Decoder).readValue(0x4000b2cc80)
    /usr/local/go/src/encoding/json/stream.go:140 +0xac
encoding/json.(*Decoder).Decode(0x4000b2cc80, {0x3066f20, 0x4000b785d0})
    /usr/local/go/src/encoding/json/stream.go:63 +0x68
k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x4000b6b920, {0x4000b30400, 0x400, 0x400})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x1e8
k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x4000867c70, 0x0, {0x3d8f808, 0x4000b7ab80})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0x70
k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000b1e340)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x60
k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x4000b7ab40)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xb4
created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x110

goroutine 346 [select]:
net/http.(*persistConn).writeLoop(0x40005bbe60)
    /usr/local/go/src/net/http/transport.go:2386 +0xa8
created by net/http.(*Transport).dialConn
    /usr/local/go/src/net/http/transport.go:1748 +0x18d0

goroutine 341 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0x40008e1d20, 0x1)
    /usr/local/go/src/runtime/sema.go:513 +0x168
sync.(*Cond).Wait(0x40008e1d10)
    /usr/local/go/src/sync/cond.go:56 +0xe4
golang.org/x/net/http2.(*pipe).Read(0x40008e1d08, {0x400024b001, 0xdff, 0xdff})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/golang.org/x/net/http2/pipe.go:65 +0xf4
golang.org/x/net/http2.transportResponseBody.Read({0x40008e1ce0}, {0x400024b001, 0xdff, 0xdff})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/golang.org/x/net/http2/transport.go:2104 +0x80
encoding/json.(*Decoder).refill(0x4000b2c8c0)
    /usr/local/go/src/encoding/json/stream.go:165 +0x18c
encoding/json.(*Decoder).readValue(0x4000b2c8c0)
    /usr/local/go/src/encoding/json/stream.go:140 +0xac
encoding/json.(*Decoder).Decode(0x4000b2c8c0, {0x3066f20, 0x400010f428})
    /usr/local/go/src/encoding/json/stream.go:63 +0x68
k8s.io/apimachinery/pkg/util/framer.(*jsonFrameReader).Read(0x4000b6b6e0, {0x4000b23500, 0x800, 0xa80})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/util/framer/framer.go:152 +0x1e8
k8s.io/apimachinery/pkg/runtime/serializer/streaming.(*decoder).Decode(0x4000867b80, 0x0, {0x3d8f808, 0x4000b7abc0})
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go:77 +0x70
k8s.io/client-go/rest/watch.(*Decoder).Decode(0x4000b1e2e0)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/client-go/rest/watch/decoder.go:49 +0x60
k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive(0x4000b7a9c0)
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:105 +0xb4
created by k8s.io/apimachinery/pkg/watch.NewStreamWatcher
    /gopath/src/k8s.io/autoscaler/cluster-autoscaler/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:76 +0x110
Stream closed EOF for autoscaler/autoscaler-aws-cluster-autoscaler-5cbcc79955-smq9k (aws-cluster-autoscaler)

```
</details>