### PR TITLE
fix(eks-public): add ingress so the cluster can communicate with the ingress controller

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -89,6 +89,15 @@ module "eks-public" {
       to_port                       = 9443
       source_cluster_security_group = true
       description                   = "Allow access from control plane to webhook port of AWS load balancer controller"
+    },
+    # nginx-ingress requires the cluster to communicate with the ingress controller
+    cluster_to_node = {
+      description                   = "Cluster to ingress-nginx webhook"
+      protocol                      = "-1"
+      from_port                     = 8443
+      to_port                       = 8443
+      type                          = "ingress"
+      source_cluster_security_group = true
     }
   }
 


### PR DESCRIPTION
Fix following error when deploying an exposed service in eks-public:

> Error: release artifact-caching-proxy failed, and has been uninstalled due to atomic being set: Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post "https://public-nginx-ingress-ingress-nginx-controller-admission.public-nginx-ingress.svc:443/networking/v1/ingresses?timeout=10s": context deadline exceeded

Ref: https://github.com/kubernetes/ingress-nginx/issues/5401#issuecomment-1205318311