### PR TITLE
fix(eks-public): add role/elb annotation too on private_subnets

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -39,6 +39,7 @@ module "vpc" {
   }
 
   private_subnet_tags = {
+    "kubernetes.io/role/elb"          = "1"
     "kubernetes.io/role/internal-elb" = "1"
   }
 }


### PR DESCRIPTION
As the ingress created with ALB has an 'internal-...' address, cf [kubernetes-management WIP PR](https://github.com/jenkins-infra/kubernetes-management/pull/2944) with these values in config/artifact-caching-proxy_aws.yaml

![image](https://user-images.githubusercontent.com/91831478/195123094-3dd30502-6a14-487f-ad85-13c69aa09840.png)

With [`nlb-type: ip`](https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html):

<img width="645" alt="image" src="https://user-images.githubusercontent.com/91831478/195123566-1e0bdb20-5b84-4943-8446-d5d1ed9b422f.png">

