### PR TITLE
Fix(eks) ensure scale down to zero is enabled for the big node pool 

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/489/head') _
-
 def dockerImage = 'jenkinsciinfra/hashicorp-tools:0.5.74'
 
 parallel(

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -75,7 +75,7 @@ module "eks" {
       # Instances of 16 vCPUs /	64 Gb each
       instance_types      = ["m5.4xlarge", "m5d.4xlarge", "m5a.4xlarge", "m5ad.4xlarge", "m5n.4xlarge", "m5dn.4xlarge"]
       spot_instance_pools = 6 # Amount of different instance that we can use
-      min_size            = 1
+      min_size            = 0
       max_size            = 50
       desired_size        = 1
       kubelet_extra_args  = "--node-labels=node.kubernetes.io/lifecycle=spot"


### PR DESCRIPTION
When there is no activity on ci.jenkins.io, no need to keep a machine up ($$$).

Digital Ocean cluster is available so always there to cold-jumpstart agents.