### PR TITLE
fix(eks-public): changing to amd64

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -58,11 +58,10 @@ module "eks-public" {
   }
 
   eks_managed_node_groups = {
-    arm-4c16g = {
-      # This worker pool is expected to host public services such as artifact-caching-proxy, etc.
-      name                 = "arm-4c16g"
-      ami_type             = "AL2_ARM_64"
-      instance_types       = ["t4g.xlarge"]
+    tiny_ondemand_linux = {
+      # This worker pool is expected to host the "technical" services such as pod autoscaler, etc.
+      name                 = "tiny-ondemand-linux"
+      instance_types       = ["t3a.xlarge"]
       capacity_type        = "ON_DEMAND"
       min_size             = 2
       max_size             = 4 # Allow manual scaling when running operations or upgrades

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -59,7 +59,7 @@ module "eks-public" {
 
   eks_managed_node_groups = {
     tiny_ondemand_linux = {
-      # This worker pool is expected to host the "technical" services such as pod autoscaler, etc.
+      # This worker pool is expected to host the "technical" services (such as the autoscaler, the load balancer controller, etc.) and the public services like artifact-caching-proxy
       name                 = "tiny-ondemand-linux"
       instance_types       = ["t3a.xlarge"]
       capacity_type        = "ON_DEMAND"


### PR DESCRIPTION
should rebuild the terraform eks-public with amd64 instead of ARM 