### PR TITLE
hotfix(eks-public): correct EBS CSI addon name

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -55,7 +55,7 @@ module "eks-public" {
     vpc-cni = {
       resolve_conflicts = "OVERWRITE"
     }
-    ebs-csi = {}
+    aws-ebs-csi-driver = {}
   }
 
   eks_managed_node_groups = {


### PR DESCRIPTION
From https://dev.to/aws-builders/install-manage-amazon-eks-add-ons-with-terraform-2dea with really interesting information like this one, to be analysed and reviewed:

> Amazon EKS automatically installs self-managed add-ons such as the Amazon VPC CNI, kube-proxy, and CoreDNS for every cluster, but you can change the default configuration of the add-ons and update them when desired.