### PR TITLE
fix(vpc): set one NAT gateway per AZ

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "region" {
   description = "AWS region"
 }
 
+# Needed for https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#one-nat-gateway-per-availability-zone
+variable "azs" {
+  description = "A list of Availability zones in the region"
+  default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
+}
+
 variable "kubernetes_version" {
   type        = string
   default     = "1.22"

--- a/vpc.tf
+++ b/vpc.tf
@@ -28,7 +28,7 @@ module "vpc" {
   # ref. https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#one-nat-gateway-per-availability-zone
   enable_nat_gateway     = true
   single_nat_gateway     = false
-  one_nat_gateway_per_az = false
+  one_nat_gateway_per_az = true
 
   enable_dns_hostnames = true
 


### PR DESCRIPTION
According to [the vpc module doc](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#nat-gateway-scenarios) the current configuration set "One NAT Gateway per subnet (default behavior)" while the comment L27 seems to indicate we want one NAT gateway per AZ instead.