### PR TITLE
fix(eks*) add cluster short name as suffix for each IRSA

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -108,19 +108,17 @@ module "eks" {
   }
 }
 
-## TODO: Proceed to renaming
-# module "eks_iam_assumable_role_autoscaler_eks" {
 module "eks_iam_role_autoscaler" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.5.2"
   create_role                   = true
-  role_name                     = "cluster-autoscaler"
+  role_name                     = "${local.autoscaler_account_name}-eks"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.autoscaler_account_namespace}:${local.autoscaler_account_name}"]
 
   tags = {
-    associated_service = "eks/${local.cluster_name}"
+    associated_service = "eks/${module.eks.cluster_id}"
   }
 }
 
@@ -128,13 +126,13 @@ module "eks_irsa_ebs" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.5.2"
   create_role                   = true
-  role_name                     = local.ebs_account_name
+  role_name                     = "${local.ebs_account_name}-eks"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.ebs_csi.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.ebs_account_namespace}:${local.ebs_account_name}"]
 
   tags = {
-    associated_service = "eks/${local.cluster_name}"
+    associated_service = "eks/${module.eks.cluster_id}"
   }
 }
 

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -133,13 +133,13 @@ module "eks_iam_assumable_role_autoscaler_eks_public" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.5.2"
   create_role                   = true
-  role_name                     = "cluster-autoscaler-eks-public"
+  role_name                     = "${local.autoscaler_account_name}-eks-public"
   provider_url                  = replace(module.eks-public.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.autoscaler_account_namespace}:${local.autoscaler_account_name}"]
 
   tags = {
-    associated_service = "eks/${local.public_cluster_name}"
+    associated_service = "eks/${module.eks-public.cluster_id}"
   }
 }
 
@@ -147,13 +147,13 @@ module "eks-public_irsa_nlb" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.5.2"
   create_role                   = true
-  role_name                     = local.nlb_account_name
+  role_name                     = "${local.nlb_account_name}-eks-public"
   provider_url                  = replace(module.eks-public.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_nlb.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.nlb_account_namespace}:${local.nlb_account_name}"]
 
   tags = {
-    associated_service = "eks/${local.public_cluster_name}"
+    associated_service = "eks/${module.eks-public.cluster_id}"
   }
 }
 
@@ -161,13 +161,13 @@ module "eks-public_irsa_ebs" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.5.2"
   create_role                   = true
-  role_name                     = local.ebs_account_name
+  role_name                     = "${local.ebs_account_name}-eks-public"
   provider_url                  = replace(module.eks-public.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.ebs_csi.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.ebs_account_namespace}:${local.ebs_account_name}"]
 
   tags = {
-    associated_service = "eks/${local.public_cluster_name}"
+    associated_service = "eks/${module.eks-public.cluster_id}"
   }
 }
 


### PR DESCRIPTION
FIx the error

```
Plan: 2 to add, 0 to change, 0 to destroy.
 module.eks_irsa_ebs.aws_iam_role.this[0]: Creating...
 ╷
 │ Error: failed creating IAM Role (ebs-csi-controller-sa): EntityAlreadyExists: Role with name ebs-csi-controller-sa already exists.
 │ 	status code: 409, request id: c00f4c83-9479-42c4-a112-659799b9b4b3
 │ 
 │   with module.eks_irsa_ebs.aws_iam_role.this[0],
 │   on .terraform/modules/eks_irsa_ebs/modules/iam-assumable-role-with-oidc/main.tf line 86, in resource "aws_iam_role" "this":
 │   86: resource "aws_iam_role" "this" {
 │ 
```