### PR TITLE
fix(eks*) define versions, IRSA(when required) and configuration policies for addons

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -39,16 +39,25 @@ module "eks" {
   # VPC is defined in vpc.tf
   vpc_id = module.vpc.vpc_id
 
-  ## Manage EKS addons with module
+  ## Manage EKS addons with module - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon
   cluster_addons = {
     coredns = {
+      addon_version     = "v1.8.7-eksbuild.3"
       resolve_conflicts = "OVERWRITE"
     }
-    kube-proxy = {}
+    kube-proxy = {
+      addon_version     = "v1.23.8-eksbuild.2"
+      resolve_conflicts = "OVERWRITE"
+    }
     vpc-cni = {
+      addon_version     = "v1.11.4-eksbuild.1"
       resolve_conflicts = "OVERWRITE"
     }
-    aws-ebs-csi-driver = {}
+    aws-ebs-csi-driver = {
+      addon_version            = "v1.11.4-eksbuild.1"
+      resolve_conflicts        = "OVERWRITE"
+      service_account_role_arn = module.eks_irsa_ebs.iam_role_arn
+    }
   }
 
   eks_managed_node_groups = {

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -45,16 +45,25 @@ module "eks-public" {
   # VPC is defined in vpc.tf
   vpc_id = module.vpc.vpc_id
 
-  ## Manage EKS addons with module
+  ## Manage EKS addons with module - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon
   cluster_addons = {
     coredns = {
+      addon_version     = "v1.8.7-eksbuild.3"
       resolve_conflicts = "OVERWRITE"
     }
-    kube-proxy = {}
+    kube-proxy = {
+      addon_version     = "v1.23.8-eksbuild.2"
+      resolve_conflicts = "OVERWRITE"
+    }
     vpc-cni = {
+      addon_version     = "v1.11.4-eksbuild.1"
       resolve_conflicts = "OVERWRITE"
     }
-    aws-ebs-csi-driver = {}
+    aws-ebs-csi-driver = {
+      addon_version            = "v1.11.4-eksbuild.1"
+      resolve_conflicts        = "OVERWRITE"
+      service_account_role_arn = module.eks-public_irsa_ebs.iam_role_arn
+    }
   }
 
   eks_managed_node_groups = {
@@ -158,13 +167,14 @@ module "eks-public_irsa_nlb" {
 }
 
 module "eks-public_irsa_ebs" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "5.5.2"
-  create_role                   = true
-  role_name                     = "${local.ebs_account_name}-eks-public"
-  provider_url                  = replace(module.eks-public.cluster_oidc_issuer_url, "https://", "")
-  role_policy_arns              = [aws_iam_policy.ebs_csi.arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.ebs_account_namespace}:${local.ebs_account_name}"]
+  source                         = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                        = "5.5.2"
+  create_role                    = true
+  role_name                      = "${local.ebs_account_name}-eks-public"
+  provider_url                   = replace(module.eks-public.cluster_oidc_issuer_url, "https://", "")
+  role_policy_arns               = [aws_iam_policy.ebs_csi.arn]
+  oidc_fully_qualified_audiences = ["sts.amazonaws.com"]
+  oidc_fully_qualified_subjects  = ["system:serviceaccount:${local.ebs_account_namespace}:${local.ebs_account_name}"]
 
   tags = {
     associated_service = "eks/${module.eks-public.cluster_id}"

--- a/iam-roles-eks.tf
+++ b/iam-roles-eks.tf
@@ -75,6 +75,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
   }
 }
 
+## https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#set-up-driver-permission
 ## No restriction on the resources: either managed outside terraform, or already scoped by conditions
 #tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "ebs" {
@@ -115,4 +116,201 @@ data "aws_iam_policy_document" "ebs" {
     #tfsec:ignore:aws-iam-no-policy-wildcards
     resources = ["*"]
   }
+
+  statement {
+    sid    = "ec2VolumesManagement"
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateSnapshot",
+      "ec2:AttachVolume",
+      "ec2:DetachVolume",
+      "ec2:ModifyVolume",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInstances",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeVolumesModifications"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ec2CreateTags"
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateTags"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = [
+      "arn:aws:ec2:*:*:volume/*",
+      "arn:aws:ec2:*:*:snapshot/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values   = ["CreateVolume", "CreateSnapshot"]
+    }
+  }
+
+  statement {
+    sid    = "ec2DeleteTags"
+    effect = "Allow"
+
+    actions = [
+      "ec2:DeleteTags"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = [
+      "arn:aws:ec2:*:*:volume/*",
+      "arn:aws:ec2:*:*:snapshot/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateVolume"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateVolume"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/CSIVolumeName"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateVolume"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/kubernetes.io/cluster/*"
+      values   = ["owned"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DeleteVolume"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DeleteVolume"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/CSIVolumeName"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DeleteVolume"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/kubernetes.io/cluster/*"
+      values   = ["owned"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DeleteSnapshot"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/CSIVolumeSnapshotName"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DeleteSnapshot"
+    ]
+
+    ## Allow wildcard for resource as it's used to request AMIs with their IDs unknwon in Terraform
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
+
 }


### PR DESCRIPTION
That one was pretty painful. No thanks to the awfull EKS documentation :'( 



- Subtly hidden in https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html (tab "AWS CLI", section "2."), it appears that the IAM Role needs to be configured with a "OIDC trusted audience". Haven't tried without this, but better sticking to the documentation. As per https://registry.terraform.io/modules/terraform-aws-modules/iam/aws/latest/submodules/iam-assumable-role-with-oidc#inputs we can use `oidc_fully_qualified_audiences` for this.

- Absent from EKS documentation: there was some IAM permissions missing to Create/Delete EC2 volumes (yes....). Found the correct permissions in the AWS EBS CSI helm chart: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#set-up-driver-permission

- Addons configuration: specify versions, policy for **all**, but the real 🔥 was that we did not specified the `csi-controller-sa` IAM role when installing the driver (neither from GUI or with Terraform).
  - Found the correct way to configure EKS Terraform's modules addons from the [source](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/28ccecefe22d81a3a7febbbc3efc17c6590f88e1/main.tf#L343) which leads to [the documentation of the Terraform AWS resource "eks_addon"](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon#argument-reference). Once validated manually in the AWS GUI console, I was able to transplant to Terraform (along with versions).


*Protip*: [`aws sts decode-authorization-message --encoded-message 'xxx'`](https://docs.aws.amazon.com/cli/latest/reference/sts/decode-authorization-message.html) is quite useful to track the missing permissions from the CSI controller logs (`kubectl -n kube-system logs -l app=ebs-csi-controller -c csi-provisioner -f`) which prints the 403 IAM error with an encoded message. The decoded messages shows which IRSA is used, along with the missing permission.