### PR TITLE
fix(eks-public) correct LB setup by using 1 EIP per AZ

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -196,11 +196,12 @@ data "aws_eks_cluster_auth" "public-cluster" {
   name = module.eks-public.cluster_id
 }
 
-# Elastic IP used for the Public Load Balancer (so that the IP never changes)
+# Elastic IPs used for the Public Load Balancer (so that the addresses never change)
 resource "aws_eip" "lb_public" {
-  vpc = true
+  count = length(module.vpc.public_subnets)
+  vpc   = true
 
   tags = {
-    "Name" = "eks-public-loadbalancer-external"
+    "Name" = "eks-public-loadbalancer-external-${count.index}"
   }
 }


### PR DESCRIPTION
With only 1 Elastic IP and 1 subnet, the loadbalancer cannot contact the EKS nodes/pods which are in a different AZs then the LB's.

There are 2 solutions:

- Enable cross-zone balancing (as per https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#cross-zone-load-balancing)
  - ✅ Only 1 static IP, easier for DNS management
  - 🔴 Less availability: if the AZ where the LB is created is failing, then no more LB

- Define multiple AZ with 1 elastic IP for each
  - ✅ High availability for the LB when an AZ goes down
  - ✅ Default supported setup by the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/#eip-allocations)
  - 🔴 we pay for each Elastic IP (https://aws.amazon.com/premiumsupport/knowledge-center/elastic-ip-charges/)


=> This PR chooses the 2nd option