### PR TITLE
cleanup(eks*) delete default (empty) node security groups

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -74,6 +74,7 @@ module "eks" {
       tags = {
         "k8s.io/cluster-autoscaler/enabled" = false # No autoscaling for these 2 machines
       },
+      create_security_group     = false
     },
     # This list of worker pool is aimed at mixed spot instances type, to ensure that we always get the most available (e.g. the cheaper) spot size
     # as per https://aws.amazon.com/blogs/compute/cost-optimization-and-resilience-eks-with-spot-instances/
@@ -91,6 +92,7 @@ module "eks" {
         "k8s.io/cluster-autoscaler/enabled"               = true,
         "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned",
       }
+      create_security_group     = false
     },
   }
 

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -84,6 +84,7 @@ module "eks-public" {
         "k8s.io/cluster-autoscaler/enabled"                      = true # Autoscaling enabled
         "k8s.io/cluster-autoscaler/${local.public_cluster_name}" = "owned",
       },
+      create_security_group     = false
     },
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -23,7 +23,7 @@ locals {
   nlb_account_name             = "aws-load-balancer-controller"
   ebs_account_namespace        = "kube-system"
   ebs_account_name             = "ebs-csi-controller-sa"
-  #AWS security groups related
+  # AWS security groups related
   aws_security_groups = ["infraci:infra.ci.jenkins.io:20.72.105.159/32", "release:release.ci.jenkins.io:52.177.88.13/32"]
 
 }


### PR DESCRIPTION
Related to #304 : the upgrade guide of the EKS module (18.x -> 19.x) mentions the need to remove the default security group created for each node group.

This security group is empty for us so that should be ok:

<img width="1816" alt="Capture d’écran 2022-12-19 à 11 32 01" src="https://user-images.githubusercontent.com/1522731/208408202-8b51ca05-37fa-4f95-beda-eebe455e62a9.png">
<img width="1800" alt="Capture d’écran 2022-12-19 à 11 40 25" src="https://user-images.githubusercontent.com/1522731/208408217-45bc729e-1d5d-493b-9865-9b236b978cec.png">
<img width="1796" alt="Capture d’écran 2022-12-19 à 11 41 09" src="https://user-images.githubusercontent.com/1522731/208408232-4f0c9d5b-1999-41f7-ab39-86c0551014b2.png">


More details: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md#eks-managed-node-groups