### PR TITLE
fix(cik8s,eks-public) add back global tags and disable cluster SG tagging

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -32,11 +32,15 @@ module "eks" {
 
   create_cluster_primary_security_group_tags = false
 
+  # Do not use interpolated values from `local` in either keys and values of provided tags (or `cluster_tags)
+  # To avoid having and implicit dependency to a resource not available when parsing the module (infamous errror `Error: Invalid for_each argument`)
+  # Ref. same error as having a `depends_on` in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337
   tags = {
     Environment        = "jenkins-infra-${terraform.workspace}"
     GithubRepo         = "aws"
     GithubOrg          = "jenkins-infra"
-    associated_service = "eks/cik8s" # Do not use interpolation from a "local" or any "resource"
+
+    associated_service = "eks/cik8s"
   }
 
   # VPC is defined in vpc.tf

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -36,9 +36,9 @@ module "eks" {
   # To avoid having and implicit dependency to a resource not available when parsing the module (infamous errror `Error: Invalid for_each argument`)
   # Ref. same error as having a `depends_on` in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337
   tags = {
-    Environment        = "jenkins-infra-${terraform.workspace}"
-    GithubRepo         = "aws"
-    GithubOrg          = "jenkins-infra"
+    Environment = "jenkins-infra-${terraform.workspace}"
+    GithubRepo  = "aws"
+    GithubOrg   = "jenkins-infra"
 
     associated_service = "eks/cik8s"
   }

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -30,14 +30,14 @@ module "eks" {
 
   cluster_endpoint_public_access = true
 
-  ## TODO: Uncomment when https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337 is resolved
-  # create_cluster_primary_security_group_tags = false
-  # tags = {
-  #   Environment        = "jenkins-infra-${terraform.workspace}"
-  #   GithubRepo         = "aws"
-  #   GithubOrg          = "jenkins-infra"
-  #   associated_service = "eks/${local.cluster_name}"
-  # }
+  create_cluster_primary_security_group_tags = false
+
+  tags = {
+    Environment        = "jenkins-infra-${terraform.workspace}"
+    GithubRepo         = "aws"
+    GithubOrg          = "jenkins-infra"
+    associated_service = "eks/cik8s" # Do not use interpolation from a "local" or any "resource"
+  }
 
   # VPC is defined in vpc.tf
   vpc_id = module.vpc.vpc_id
@@ -73,7 +73,7 @@ module "eks" {
       tags = {
         "k8s.io/cluster-autoscaler/enabled" = false # No autoscaling for these 2 machines
       },
-      create_security_group = false
+      attach_cluster_primary_security_group = true
     },
     # This list of worker pool is aimed at mixed spot instances type, to ensure that we always get the most available (e.g. the cheaper) spot size
     # as per https://aws.amazon.com/blogs/compute/cost-optimization-and-resilience-eks-with-spot-instances/
@@ -91,7 +91,7 @@ module "eks" {
         "k8s.io/cluster-autoscaler/enabled"               = true,
         "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned",
       }
-      create_security_group = false
+      attach_cluster_primary_security_group = true
     },
   }
 

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -36,11 +36,14 @@ module "eks-public" {
 
   create_cluster_primary_security_group_tags = false
 
+  # Do not use interpolated values from `local` in either keys and values of provided tags (or `cluster_tags)
+  # To avoid having and implicit dependency to a resource not available when parsing the module (infamous errror `Error: Invalid for_each argument`)
+  # Ref. same error as having a `depends_on` in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337
   tags = {
     Environment        = "jenkins-infra-${terraform.workspace}"
     GithubRepo         = "aws"
     GithubOrg          = "jenkins-infra"
-    associated_service = "eks/eks-public" # Do not use interpolation from a "local" or any "resource"
+    associated_service = "eks/eks-public"
   }
 
   # VPC is defined in vpc.tf

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -34,14 +34,14 @@ module "eks-public" {
     resources        = ["secrets"]
   }
 
-  ## TODO: Uncomment when https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337 is resolved
-  # create_cluster_primary_security_group_tags = false
-  # tags = {
-  #   Environment        = "jenkins-infra-${terraform.workspace}"
-  #   GithubRepo         = "aws"
-  #   GithubOrg          = "jenkins-infra"
-  #   associated_service = "eks/${local.public_cluster_name}"
-  # }
+  create_cluster_primary_security_group_tags = false
+
+  tags = {
+    Environment        = "jenkins-infra-${terraform.workspace}"
+    GithubRepo         = "aws"
+    GithubOrg          = "jenkins-infra"
+    associated_service = "eks/eks-public" # Do not use interpolation from a "local" or any "resource"
+  }
 
   # VPC is defined in vpc.tf
   vpc_id = module.vpc.vpc_id


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3305.

This PR adds back the tagging feature for the EKS clusters (defined using the eks terraform module).

By using static values not using Terraform `locals` values, the dependency tree is now complete and does not throw any `depends_on` error.


It allows disabling the cluster security group tagging, ensuring that the AWS LB controller is not confused by finding 2 sec. groups with the expected tag (ref. https://github.com/jenkins-infra/helpdesk/issues/3305#issuecomment-1410408113).