### PR TITLE
set cik8s agent node pools disk size to 200G

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -91,13 +91,14 @@ module "eks" {
       name          = "spot-linux-4xlarge"
       capacity_type = "SPOT"
       # Instances of 16 vCPUs /	64 Gb each
-      instance_types      = ["m5.4xlarge", "m5d.4xlarge", "m5a.4xlarge", "m5ad.4xlarge", "m5n.4xlarge", "m5dn.4xlarge"]
-      disk_size           = 200 # Same size as DigitalOcean's size. TODO: Synchronize values between all cloud providers
-      spot_instance_pools = 6 # Amount of different instance that we can use
-      min_size            = 0
-      max_size            = 50
-      desired_size        = 1
-      kubelet_extra_args  = "--node-labels=node.kubernetes.io/lifecycle=spot"
+      instance_types       = ["m5.4xlarge", "m5d.4xlarge", "m5a.4xlarge", "m5ad.4xlarge", "m5n.4xlarge", "m5dn.4xlarge"]
+      launch_template_name = ""
+      disk_size            = 200 # Same size as DigitalOcean's size. TODO: Synchronize values between all cloud providers
+      spot_instance_pools  = 6   # Amount of different instance that we can use
+      min_size             = 0
+      max_size             = 50
+      desired_size         = 1
+      kubelet_extra_args   = "--node-labels=node.kubernetes.io/lifecycle=spot"
       tags = {
         "k8s.io/cluster-autoscaler/enabled"               = true,
         "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned",

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -92,6 +92,7 @@ module "eks" {
       capacity_type = "SPOT"
       # Instances of 16 vCPUs /	64 Gb each
       instance_types      = ["m5.4xlarge", "m5d.4xlarge", "m5a.4xlarge", "m5ad.4xlarge", "m5n.4xlarge", "m5dn.4xlarge"]
+      disk_size           = 200 # Same size as DigitalOcean's size. TODO: Synchronize values between all cloud providers
       spot_instance_pools = 6 # Amount of different instance that we can use
       min_size            = 0
       max_size            = 50


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3423, this PR increases the size of the cik8s's agents node pool from 20G (default) to 200 (same as current size in DigitalOcean cluster).

Documentation about this change in the Terraform's EKS module we use:

- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1739
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1830