### PR TITLE
feat(release.ci): update public IP to allow incoming SSH connections to agents

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -24,6 +24,5 @@ locals {
   ebs_account_namespace        = "kube-system"
   ebs_account_name             = "ebs-csi-controller-sa"
   # AWS security groups related
-  aws_security_groups = ["infraci:infra.ci.jenkins.io:20.96.66.246/32", "release:release.ci.jenkins.io:52.177.88.13/32"]
-
+  aws_security_groups = ["infraci:infra.ci.jenkins.io:20.96.66.246/32", "release:release.ci.jenkins.io:20.96.66.246/32"]
 }


### PR DESCRIPTION
Set "release" AWS security group to the same IP as "infraci" since release.ci.jenkins.io has been moved from the `prodpublick8s` cluster (`52.177.88.13` public IP defined in the `MC_prodpublick8s_prodpublick8s_eastus2` resource group) to the `privatek8s` one. (`20.96.66.246` public IP defined in the `MC_prod-privatek8s_privatek8s-emerging-ram_eastus2` resource group)

Similar to https://github.com/jenkins-infra/aws/pull/322

Ref: https://github.com/jenkins-infra/helpdesk/issues/2844