### PR TITLE
cleanup: remove release.ci unused AWS security group

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -24,5 +24,5 @@ locals {
   ebs_account_namespace        = "kube-system"
   ebs_account_name             = "ebs-csi-controller-sa"
   # AWS security groups related
-  aws_security_groups = ["infraci:infra.ci.jenkins.io:20.96.66.246/32", "release:release.ci.jenkins.io:20.96.66.246/32"]
+  aws_security_groups = ["infraci:infra.ci.jenkins.io:20.96.66.246/32"]
 }


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/aws/pull/373#issuecomment-1488637908 & https://github.com/jenkins-infra/kubernetes-management/pull/3774

As none of the current release jobs uses VM agent and as we're not building Docker image on release.ci.jenkins.io (yet), this PR removes the corresponding AWS security group values.