### PR TITLE
feat(eks) split and optimize node pools for ci.jenkins.io usage (bom vs. plugins)

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -122,6 +122,50 @@ module "eks" {
       }
       attach_cluster_primary_security_group = true
     },
+    spot_linux_24xlarge = {
+      # 24xlarge: Instances supporting 23 pods (limited to 4 vCPUs/8 Gb) each with 1 vCPU/1Gb margin
+      name          = "spot-linux-24xlarge"
+      capacity_type = "SPOT"
+      # Less than 5% eviction rate, cost below $0.05 per pod per hour
+      instance_types = [
+        "m5.24xlarge",
+        "c5.24xlarge",
+      ]
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 575 # With 23 pods / machine, that can use ~25 Gb each at the same time (`emptyDir`)
+            volume_type           = "gp3"
+            iops                  = 3000 # Max included with gp3 without additional cost
+            throughput            = 125  # Max included with gp3 without additional cost
+            encrypted             = false
+            delete_on_termination = true
+          }
+        }
+      }
+      spot_instance_pools = 2 # Amount of different instance that we can use
+      min_size            = 0
+      max_size            = 15
+      desired_size        = 0
+      kubelet_extra_args  = "--node-labels=node.kubernetes.io/lifecycle=spot"
+      tags = {
+        "k8s.io/cluster-autoscaler/enabled"               = true,
+        "k8s.io/cluster-autoscaler/${local.cluster_name}" = "owned",
+      }
+      attach_cluster_primary_security_group = true
+      labels         = {
+        "ci.jenkins.io/agents-density"                    = 23,
+      }
+      taints         = [
+        {
+          key    = "ci.jenkins.io/bom"
+          value  = "true"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+      // TODO: taints + label (nodeselector): https://github.com/jenkins-infra/release/blob/41877fe2881e5b211550536ecb3d5b0123a08534/PodTemplates.d/package-windows.yaml#L39-L50
+    },
   }
 
   # Allow egress from nodes (and pods...)


### PR DESCRIPTION
This PR originates from https://github.com/jenkins-infra/helpdesk/issues/3502 trying to control cloud costs.

The jenkinsci/bom builds on ci.jenkins.io are complex builds which generates a lot of parallel steps (~300) which is quite costy. Their rate is increasing and it also competes for agent resources with plugins (or other builds).

This PR is a first step forward which introduces 1 new node pool dedicated for bom build and 1 optimization to the current AWS node pool. I should have done in 2 PRs, but the Node pools manipulation on EKS are abusively long (~30 min) so I prefer changing them in one shot.

- Optimization to the current nodepool switches to the "compute optimized" instances line to decrease the costs and the probablity of spot eviction
  - Ref. https://docs.google.com/spreadsheets/d/1_C0I0jE-X0e0vDcdKOFIWcnwpOqWC8RQ4YOCgXNnplY/edit#gid=292621391
  - Less memory than the previous instances, but the current usage is low (20 to 25%) while vCPU are quite used and would benefit from a little boost

<img width="1776" alt="Capture d’écran 2023-04-17 à 08 21 17" src="https://user-images.githubusercontent.com/1522731/232401125-b76687eb-8c6a-46a7-933d-ecd08395072a.png">


- The new node pool is expected to be used by the `bom` build only. It's sized under the assumption that `bom` build is massively parallelized: it's costing a lot of money when its parallel stages are waiting for an agent (+ the retries).
  - With 23 pod per nodes, and 15 nodes max., the initial sizing ensure that a single `bom` build can be treated in one shot (once node pool is autoscaled) with room for breathing (when a spot instance is evicted, it's 23 agents evicted: they can be taken immediatly by another node)
  - 2 family of instances are used due to the tentative to have lowest costs and a low eviction rate
  - No assumption on the pods sizing for now: this node pool will be tested on a `bom` PR first and we'll measure the CPU and memory usage to fine tune the limits in the context of these machines.
  - Taints are set for this node pool to ensure that it will only used by customized pod templates (and not by default)
  - Pricing was calculated here: Ref. https://docs.google.com/spreadsheets/d/1_C0I0jE-X0e0vDcdKOFIWcnwpOqWC8RQ4YOCgXNnplY/edit#gid=292621391
  - A visual aide to better understand the pod packing: https://learnk8s.io/kubernetes-instance-calculator

