### PR TITLE
fix(cik8s) manage aws_auth configmap to add the new AWS SSO infra-admin group

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -28,7 +28,35 @@ module "eks" {
     resources        = ["secrets"]
   }
 
+  create_aws_auth_configmap = true
+  manage_aws_auth_configmap = true
+
   cluster_endpoint_public_access = true
+
+  aws_auth_users = [
+    # User impersonated when using the CloudBees IAM Accounts (e.g. humans)
+    {
+      userarn  = "arn:aws:iam::${local.aws_account_id}:role/AWSReservedSSO_infra-admin_eaf058d61d35b904",
+      username = "infra-admin",
+      groups   = ["system:masters"],
+    },
+    # User defined in infra.ci.jenkins.io system to operate terraform
+    {
+      userarn  = "arn:aws:iam::${local.aws_account_id}:user/terraform-aws-production",
+      username = "terraform-aws-production",
+      groups   = ["system:masters"],
+    },
+    # User for administratin the charts from github.com/jenkins-infra/kubernetes-management
+    {
+      userarn  = data.aws_iam_user.eks_charter.arn,
+      username = data.aws_iam_user.eks_charter.user_name,
+      groups   = ["system:masters"],
+    },
+  ]
+
+  aws_auth_accounts = [
+    local.aws_account_id,
+  ]
 
   create_cluster_primary_security_group_tags = false
 

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -113,7 +113,7 @@ module "eks-public" {
       username = "terraform-aws-production",
       groups   = ["system:masters"],
     },
-    # User for administrating the charts from github.com/jenkins-infra/kubernetes-management
+    # User for administratin the charts from github.com/jenkins-infra/kubernetes-management
     {
       userarn  = data.aws_iam_user.eks_public_charter.arn,
       username = data.aws_iam_user.eks_public_charter.user_name,


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3521, I wasn't able to access the cik8s cluster to check its namespaces: neither locally or on my AWS Console.

This PR fixes the issue for the whole SRE team: same thing as https://github.com/jenkins-infra/aws/pull/393 but for the `cik8s` cluster