### PR TITLE
fix(cik8s) add missing kubernetes provider

### DIFF
--- a/cik8s-cluster.tf
+++ b/cik8s-cluster.tf
@@ -22,6 +22,12 @@ module "cik8s" {
   # useful for autoscaler, EKS addons and any AWS APi usage
   enable_irsa = true
 
+  # Specifying the kubernetes provider to use for this cluster
+  # Note: this should be done AFTER initial cluster creation (bootstrap)
+  providers = {
+    kubernetes = kubernetes.cik8s
+  }
+
   create_kms_key = false
   cluster_encryption_config = {
     provider_key_arn = aws_kms_key.cik8s.arn
@@ -284,9 +290,25 @@ module "cik8s_irsa_ebs" {
   }
 }
 
+
 # Reference the existing user for administrating the charts from github.com/jenkins-infra/charts
 data "aws_iam_user" "cik8s_charter" {
   user_name = "cik8s-charter"
+}
+
+data "aws_eks_cluster" "cik8s" {
+  name = local.cik8s_cluster_name
+}
+
+data "aws_eks_cluster_auth" "cik8s" {
+  name = local.cik8s_cluster_name
+}
+
+provider "kubernetes" {
+  alias                  = "cik8s"
+  host                   = data.aws_eks_cluster.cik8s.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cik8s.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cik8s.token
 }
 
 ## No restriction on the resources: either managed outside terraform, or already scoped by conditions

--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -24,6 +24,7 @@ module "eks-public" {
   enable_irsa = true
 
   # Specifying the kubernetes provider to use for this cluster
+  # Note: this should be done AFTER initial cluster creation (bootstrap)
   providers = {
     kubernetes = kubernetes.eks-public
   }


### PR DESCRIPTION
Deployment of https://github.com/jenkins-infra/aws/pull/398 failed with the dreaded `dial tcp [::1]:80: connect: connection refused` after cluster creation.


This PR applies the trick from https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2501#issuecomment-1468836777 to fix this issue