### PR TITLE
chore(updatecli) fix manifest after renaming eks-cluster to cik8s-cluster

### DIFF
--- a/updatecli/updatecli.d/terraform-modules/eks.yml
+++ b/updatecli/updatecli.d/terraform-modules/eks.yml
@@ -28,12 +28,12 @@ sources:
 
 targets:
   upgradeModuleVersion:
-    name: "Update the Terraform module version of terraform-aws-modules/eks/aws in eks-cluster.tf"
+    name: "Update the Terraform module version of terraform-aws-modules/eks/aws in cik8s-cluster.tf"
     kind: file
     sourceid: getLatestVersion
     spec:
       files:
-        - eks-cluster.tf
+        - cik8s-cluster.tf
         - eks-public-cluster.tf
       matchpattern: >-
         source(.*)=(.*)"terraform-aws-modules/eks/aws"(\r\n|\r|\n)(.*)version(.*)=(.*)

--- a/updatecli/updatecli.d/terraform-modules/irsa.yaml
+++ b/updatecli/updatecli.d/terraform-modules/irsa.yaml
@@ -33,7 +33,7 @@ targets:
     sourceid: getLatestVersion
     spec:
       files:
-        - eks-cluster.tf
+        - cik8s-cluster.tf
         - eks-public-cluster.tf
       matchpattern: >-
         source(.*)=(.*)"terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"(\r\n|\r|\n)(.*)version(.*)=(.*)


### PR DESCRIPTION
Closes #392  (superseds) as the manifest fingerprints will change.