### PR TITLE
refactor(cik8s,eks-public) define infraciadmin SA with a terraform module

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -220,9 +220,26 @@ module "eks-public_irsa_ebs" {
   }
 }
 
-# Reference the existing user for administrating the charts from github.com/jenkins-infra/kubernetes-management
+
+## Todo: check if still neded once jenkins-infra/helpdesk-3679 is closed
+# Reference the existing user for administrating the charts from jenkins-infra/kubernetes-management
 data "aws_iam_user" "eks_public_charter" {
   user_name = "eks-public-charter"
+}
+# Configure the jenkins-infra/kubernetes-management admin service account
+module "eks_public_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.eks-public
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = module.eks-public.cluster_name
+  cluster_hostname           = module.eks-public.cluster_endpoint
+  cluster_ca_certificate_b64 = module.eks-public.cluster_certificate_authority_data
+}
+
+output "kubeconfig_eks_public" {
+  sensitive = true
+  value     = module.eks_public_admin_sa.kubeconfig
 }
 
 # Reference to allow configuration of the Terraform's kubernetes provider (in providers.tf)

--- a/providers.tf
+++ b/providers.tf
@@ -20,3 +20,10 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.eks-public.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.public-cluster.token
 }
+
+provider "kubernetes" {
+  alias                  = "cik8s"
+  host                   = data.aws_eks_cluster.cik8s.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cik8s.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cik8s.token
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3679

Same as https://github.com/jenkins-infra/digitalocean/pull/134 + https://github.com/jenkins-infra/digitalocean/pull/136 but for AWS

Note: There is an AWS IAM "eks_charter" user added to the [EKS Auth configmap](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html) : gotta check if we cannot clean it up if the switch to `infraciadmin` SA works without requiring AWS IAM auth.