### PR TITLE
chore(eks-public) update deprecated EIP terraform configuration

### DIFF
--- a/eks-public-cluster.tf
+++ b/eks-public-cluster.tf
@@ -236,8 +236,8 @@ data "aws_eks_cluster_auth" "public-cluster" {
 
 # Elastic IPs used for the Public Load Balancer (so that the addresses never change)
 resource "aws_eip" "lb_public" {
-  count = length(module.vpc.public_subnets)
-  vpc   = true
+  count  = length(module.vpc.public_subnets)
+  domain = "vpc"
 
   tags = {
     "Name" = "eks-public-loadbalancer-external-${count.index}"


### PR DESCRIPTION
As per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip#vpc, the attribute `vpc` is deprecated for resources of type `aws_eip`.

This PR fixes the warning message: no change expected.