### PR TITLE
chore: add CloudBees tags to conform with their AWS account

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -2,8 +2,12 @@ provider "aws" {
   region = var.region
   default_tags {
     tags = {
-      scope      = "terraform-managed"
-      repository = "jenkins-infra/aws"
+      scope           = "terraform-managed"
+      repository      = "jenkins-infra/aws"
+      "cb:user"       = "dduportal"
+      "cb:production" = "production"
+      "cb:owner"      = "Community-Team"
+      "cb-env-type"   = "external"
     }
   }
 }


### PR DESCRIPTION
CloudBees owns (and pays for) the AWS account where the Jenkins project hosts the following services:

- Update center (updates.jenkins.io)
- Census (census.jenkins.io)
- Usage (usage.jenkins.io)
- Two EKS clusters used to run workloads for ci.jenkins.io


This PR adds labels to our terraform-managed resources in order to comply with their internal rules.