### PR TITLE
feat: restrict SSH access to VMs

### DIFF
--- a/census.jenkins.io.tf
+++ b/census.jenkins.io.tf
@@ -1,0 +1,11 @@
+data "aws_instance" "census_jenkins_io" {
+  filter {
+    name   = "tag:Name"
+    values = ["jenkins-census"]
+  }
+}
+
+resource "aws_network_interface_sg_attachment" "ssh_to_census" {
+  security_group_id    = aws_security_group.restricted_ssh.id
+  network_interface_id = data.aws_instance.census_jenkins_io.network_interface_id
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,3 @@
+module "jenkins_infra_shared_data" {
+  source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
+}

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,53 @@
+data "aws_vpc" "default" {
+  id = "vpc-70a4b915"
+}
+
+resource "aws_security_group" "restricted_ssh" {
+  name        = "restricted-ssh"
+  description = "Allow inbound SSH only from trusted sources (admins or VPN)"
+  vpc_id      = data.aws_vpc.default.id
+
+  tags = local.common_tags
+}
+
+resource "aws_security_group" "unrestricted_http" {
+  name        = "unrestricted-http"
+  description = "Allow HTTP(S) from everywhere (public services)"
+  vpc_id      = data.aws_vpc.default.id
+
+  tags = local.common_tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_ssh_from_admins" {
+  for_each = toset(flatten(concat(
+    module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],             # permanent agent of update_center2
+    module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"], # ephemeral agents for crawler
+    module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],             # Terraform management + VPN VM
+    module.jenkins_infra_shared_data.outbound_ips["private.vpn.jenkins.io"],            # connections routed through the VPN
+  )))
+
+  description       = "Allow admin (or platform) IPv4 for inbound SSH"
+  security_group_id = aws_security_group.restricted_ssh.id
+  cidr_ipv4         = "${each.value}/32"
+  from_port         = 22
+  ip_protocol       = "tcp"
+  to_port           = 22
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_http_internet" {
+  description       = "Allow HTTP from everywhere (public Internet)"
+  security_group_id = aws_security_group.unrestricted_http.id
+  cidr_ipv4         = "0.0.0.0/32"
+  from_port         = 80
+  ip_protocol       = "tcp"
+  to_port           = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_https_internet" {
+  description       = "Allow HTTP from everywhere (public Internet)"
+  security_group_id = aws_security_group.unrestricted_http.id
+  cidr_ipv4         = "0.0.0.0/32"
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
+}

--- a/pkg.origin.jenkins.io.tf
+++ b/pkg.origin.jenkins.io.tf
@@ -1,0 +1,11 @@
+data "aws_instance" "pkg_origin_jenkins_io" {
+  filter {
+    name   = "tag:Name"
+    values = ["jenkins-pkg"]
+  }
+}
+
+resource "aws_network_interface_sg_attachment" "ssh_to_pkg" {
+  security_group_id    = aws_security_group.restricted_ssh.id
+  network_interface_id = data.aws_instance.pkg_origin_jenkins_io.network_interface_id
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = var.region
+  region = "us-east-1"
   default_tags {
     tags = local.common_tags
   }

--- a/usage.jenkins.io.tf
+++ b/usage.jenkins.io.tf
@@ -1,0 +1,12 @@
+data "aws_instance" "usage_jenkins_io" {
+
+  filter {
+    name   = "tag:Name"
+    values = ["jenkins-usage"]
+  }
+}
+
+resource "aws_network_interface_sg_attachment" "ssh_to_usage" {
+  security_group_id    = aws_security_group.restricted_ssh.id
+  network_interface_id = data.aws_instance.usage_jenkins_io.network_interface_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,0 @@
-variable "region" {
-  type        = string
-  default     = "us-east-2"
-  description = "AWS region"
-}


### PR DESCRIPTION
This PR ensures that only administrator IPs can access the 3 VMs (not Terrafor managed).

It also allows the outbound IPs from the infrastructure interacting (in SSH/Rsync) with these machines:
- trusted.ci.jenkins.io network (permanent agent for update_center2 updates but also ephemeral agents for crawler)
- privatek8s.jenkins.io network (release.ci need to access the VM when packaging the Core releases and infra.ci.jenkins.io need to administrate the VMs with terraform-

This PR also create a SG to allow inbound connections (HTTP and HTTPS) from the internet: the goal is to remove the current SG manually managed in favor of this new one.

cc @MarkEWaite @lemeurherve @smerle33 @timja @daniel-beck @wadeck if you need to add your own public Ip to reach the pkg VM (with the current update center): https://github.com/jenkins-infra/shared-tools/blob/b54f99a57ab10b73e9700ac23eec3075dd1ed3af/terraform/modules/jenkins-infra-shared-data/outputs.tf#L1-L8