### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,24 +1,12 @@
-parallel(
-  failFast: false,
-  'terraform': {
-    terraform(
-      stagingCredentials: [
-        string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'staging-terraform-aws-access-key'),
-        string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'staging-terraform-aws-secret-key'),
-        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-aws-backend-config'),
-      ],
-      productionCredentials: [
-        string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'production-terraform-aws-access-key'),
-        string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'production-terraform-aws-secret-key'),
-        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-aws-backend-config'),
-      ],
-    )
-  },
-  // TODO:; split into  2 jobs
-  // 'updatecli': {
-  //   updatecli(action: 'diff')
-  //   if (env.BRANCH_IS_PRIMARY) {
-  //     updatecli(action: 'apply', cronTriggerExpression: '@daily')
-  //   }
-  // },
+terraform(
+  stagingCredentials: [
+    string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'staging-terraform-aws-access-key'),
+    string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'staging-terraform-aws-secret-key'),
+    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-aws-backend-config'),
+  ],
+  productionCredentials: [
+    string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'production-terraform-aws-access-key'),
+    string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'production-terraform-aws-secret-key'),
+    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-aws-backend-config'),
+  ],
 )

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,8 @@
+if (env.BRANCH_IS_PRIMARY) {
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
+}
+
 terraform(
   stagingCredentials: [
     string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'staging-terraform-aws-access-key'),
@@ -9,4 +14,5 @@ terraform(
     string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'production-terraform-aws-secret-key'),
     file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-aws-backend-config'),
   ],
+  // publishReports: ['jenkins-infra-data-reports/aws.json'],
 )

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/870/head') _
+
 updatecli(action: 'diff')
 if (env.BRANCH_IS_PRIMARY) {
     updatecli(action: 'apply', cronTriggerExpression: '@daily')

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+}

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/870/head') _
-
 updatecli(action: 'diff')
 if (env.BRANCH_IS_PRIMARY) {
     updatecli(action: 'apply', cronTriggerExpression: '@daily')

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,4 +1,7 @@
 updatecli(action: 'diff')
+
 if (env.BRANCH_IS_PRIMARY) {
-    updatecli(action: 'apply', cronTriggerExpression: '@daily')
+    // Only trigger a daily check on the principal branch
+    properties([pipelineTriggers([cron('@daily')])])
+    updatecli(action: 'apply')
 }

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,6 +1,6 @@
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,3 +1,4 @@
+---
 github:
   user: "jenkins-infra-updatecli"
   email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778